### PR TITLE
Multiple improvements, make the script more flexible

### DIFF
--- a/deploy/route53.sh
+++ b/deploy/route53.sh
@@ -11,26 +11,27 @@ if [ $# -lt 2 ]; then
   exit 1
 fi
 
-if [ ! -e ./r53 ]; then
-  mkdir ./r53
-fi
+tmpDir="/tmp/r53"
 
+if [ ! -e $tmpDir ]; then
+  mkdir $tmpDir
+fi
 
 zone=$1
 elbName=$2
 
 # File to contain our provisioning settings for Route 53
-rel_json=./r53/route53.json_$zone
+rel_json=$tmpDir/route53.json_$zone
 abs_json=$(cd $(dirname "${rel_json}") && pwd -P)/$(basename "${rel_json}")
 
 # Describe the ELB to get the zone ID and DNS
-aws elb describe-load-balancers --load-balancer-name ${elbName} > ./r53/elb.json_$zone
-elbZone=`./jq --raw-output '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID' ./r53/elb.json_$zone`
-elbDns=`./jq --raw-output '.LoadBalancerDescriptions[0].DNSName' ./r53/elb.json_$zone`
+aws elb describe-load-balancers --load-balancer-name ${elbName} > $tmpDir/elb.json_$zone
+elbZone=`./jq --raw-output '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID' $tmpDir/elb.json_$zone`
+elbDns=`./jq --raw-output '.LoadBalancerDescriptions[0].DNSName' $tmpDir/elb.json_$zone`
 
 # Describe the Zone to get its Name
-aws route53 get-hosted-zone --id ${zone} > ./r53/r53.json_$zone
-r53Name=`./jq --raw-output '.HostedZone.Name' ./r53/r53.json_$zone`
+aws route53 get-hosted-zone --id ${zone} > $tmpDir/r53.json_$zone
+r53Name=`./jq --raw-output '.HostedZone.Name' $tmpDir/r53.json_$zone`
 
 # Write our command for AWS Route 53 to a json file
 cat > ${rel_json} <<EOF
@@ -57,19 +58,21 @@ EOF
 aws route53 change-resource-record-sets \
   --hosted-zone-id ${zone} \
   --change-batch file://${abs_json} \
-  > ./r53/route53-change.json_$zone
+  > $tmpDir/route53-change.json_$zone
 
 # Get the ID for our change request
-changeId=`./jq --raw-output '.ChangeInfo.Id' ./r53/route53-change.json_$zone`
+changeId=`./jq --raw-output '.ChangeInfo.Id' $tmpDir/route53-change.json_$zone`
 status=PENDING
 
 # Poll the status of our change request until it is "INSYNC"
 while [ "${status}" = "PENDING" ]; do
   sleep 5
-  aws route53 get-change --id ${changeId} > ./r53/route53-change.json_$zone
-  status=`./jq --raw-output '.ChangeInfo.Status' ./r53/route53-change.json_$zone`
+  aws route53 get-change --id ${changeId} > $tmpDir/route53-change.json_$zone
+  status=`./jq --raw-output '.ChangeInfo.Status' $tmpDir/route53-change.json_$zone`
   echo "Route53 ALIAS status: ${status}"
 done
+
+find $tmpDir -type f -delete
 
 # Wait another 30 seconds while the Internets update
 sleep 30

--- a/deploy/route53.sh
+++ b/deploy/route53.sh
@@ -23,6 +23,10 @@ aws elb describe-load-balancers --load-balancer-name ${elbName} > elb.json
 elbZone=`./jq --raw-output '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID' elb.json`
 elbDns=`./jq --raw-output '.LoadBalancerDescriptions[0].DNSName' elb.json`
 
+# Describe the Zone to get its Name
+aws route53 get-hosted-zone --id ${zone} > r53.json
+r53Name=`./jq --raw-output '.HostedZone.Name' r53.json`
+
 # Write our command for AWS Route 53 to a json file
 cat > ${rel_json} <<EOF
 {
@@ -31,7 +35,7 @@ cat > ${rel_json} <<EOF
     {
       "Action": "UPSERT",
       "ResourceRecordSet": {
-        "Name": "proseand.co.nz.",
+        "Name": "${r53Name}",
         "Type": "A",
         "AliasTarget": {
           "HostedZoneId": "${elbZone}",

--- a/deploy/route53.sh
+++ b/deploy/route53.sh
@@ -11,21 +11,26 @@ if [ $# -lt 2 ]; then
   exit 1
 fi
 
+if [ ! -e ./r53 ]; then
+  mkdir ./r53
+fi
+
+
 zone=$1
 elbName=$2
 
 # File to contain our provisioning settings for Route 53
-rel_json=./route53.json
+rel_json=./r53/route53.json_$zone
 abs_json=$(cd $(dirname "${rel_json}") && pwd -P)/$(basename "${rel_json}")
 
 # Describe the ELB to get the zone ID and DNS
-aws elb describe-load-balancers --load-balancer-name ${elbName} > elb.json
-elbZone=`./jq --raw-output '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID' elb.json`
-elbDns=`./jq --raw-output '.LoadBalancerDescriptions[0].DNSName' elb.json`
+aws elb describe-load-balancers --load-balancer-name ${elbName} > ./r53/elb.json_$zone
+elbZone=`./jq --raw-output '.LoadBalancerDescriptions[0].CanonicalHostedZoneNameID' ./r53/elb.json_$zone`
+elbDns=`./jq --raw-output '.LoadBalancerDescriptions[0].DNSName' ./r53/elb.json_$zone`
 
 # Describe the Zone to get its Name
-aws route53 get-hosted-zone --id ${zone} > r53.json
-r53Name=`./jq --raw-output '.HostedZone.Name' r53.json`
+aws route53 get-hosted-zone --id ${zone} > ./r53/r53.json_$zone
+r53Name=`./jq --raw-output '.HostedZone.Name' ./r53/r53.json_$zone`
 
 # Write our command for AWS Route 53 to a json file
 cat > ${rel_json} <<EOF
@@ -52,17 +57,17 @@ EOF
 aws route53 change-resource-record-sets \
   --hosted-zone-id ${zone} \
   --change-batch file://${abs_json} \
-  > ./route53-change.json
+  > ./r53/route53-change.json_$zone
 
 # Get the ID for our change request
-changeId=`./jq --raw-output '.ChangeInfo.Id' ./route53-change.json`
+changeId=`./jq --raw-output '.ChangeInfo.Id' ./r53/route53-change.json_$zone`
 status=PENDING
 
 # Poll the status of our change request until it is "INSYNC"
 while [ "${status}" = "PENDING" ]; do
   sleep 5
-  aws route53 get-change --id ${changeId} > ./route53-change.json
-  status=`./jq --raw-output '.ChangeInfo.Status' ./route53-change.json`
+  aws route53 get-change --id ${changeId} > ./r53/route53-change.json_$zone
+  status=`./jq --raw-output '.ChangeInfo.Status' ./r53/route53-change.json_$zone`
   echo "Route53 ALIAS status: ${status}"
 done
 


### PR DESCRIPTION
- The record name is dynamicaly loaded, instead of manually specified
- The script is parallelizable : 

```
variable "zones" {
  default = {
    "0" = "example.net"
    "1" = "example.com"
  }
}

variable "zones_counter" {
    default = 2
}

resource "aws_route53_record" "global_records" {
    count = "${var.zones_counter}"
    zone_id = "${element(aws_route53_zone.primary.*.zone_id, count.index)}"
    name = "${concat("www.",element(aws_route53_zone.primary.*.name, count.index))}"
    type = "CNAME"
    ttl = "300"
    records = ["${element(aws_route53_zone.primary.*.name, count.index)}"]
  provisioner "local-exec" {
    command = "./route53.sh ${element(aws_route53_zone.primary.*.zone_id, count.index)} elb"
  }
```
